### PR TITLE
Turn off Occopus ping test on CB platform

### DIFF
--- a/adaptors/occopus_adaptor.py
+++ b/adaptors/occopus_adaptor.py
@@ -322,6 +322,8 @@ class OccopusAdaptor(abco.Adaptor):
               .setdefault("description", {}) \
               .setdefault("opened_port", capabilites["opened_port"].value)
         self._node_data_get_context_section()
+        self.node_data.setdefault("health_check", {}) \
+            .setdefault("ping",False)
 
     def _node_data_get_nova_host_properties(self, node, key):
         """


### PR DESCRIPTION
The current version of the CB platform firewall system does not have ICMP filter options. Therefore when you deploy an app, the infrastructure won't build up correctly. 
