### PR TITLE
Support optional exporters

### DIFF
--- a/system/cadvisor.yaml
+++ b/system/cadvisor.yaml
@@ -1,0 +1,66 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: cadvisor
+  namespace: micado-worker
+  labels:
+    app.kubernetes.io/name: cadvisor
+    app.kubernetes.io/managed-by: micado
+    app.kubernetes.io/version: v0.33.0
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cadvisor
+      app.kubernetes.io/managed-by: micado
+      app.kubernetes.io/version: v0.33.0
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cadvisor
+        app.kubernetes.io/managed-by: micado
+        app.kubernetes.io/version: v0.33.0
+    spec:
+      containers:
+      - name: cadvisor
+        image: google/cadvisor:v0.33.0
+        args:
+        - --docker_only=true
+        - --housekeeping_interval=5s
+        - --disable_metrics=tcp,udp,disk
+        - --max_housekeeping_interval=15s
+        ports:
+        - containerPort: 8080
+        resources:
+          requests:
+            cpu: 25m
+        volumeMounts:
+        - name: cadvisor-root
+          mountPath: /rootfs
+          readOnly: true
+        - name: cadvisor-run
+          mountPath: /var/run
+        - name: cadvisor-sys
+          mountPath: /sys
+          readOnly: true
+        - name: cadvisor-docker
+          mountPath: /var/lib/docker
+          readOnly: true
+        - name: cadvisor-disk
+          mountPath: /dev/disk
+      priorityClassName: micado-priority
+      volumes:
+      - name: cadvisor-root
+        hostPath:
+          path: /
+      - name: cadvisor-run
+        hostPath:
+          path: /var/run
+      - name: cadvisor-sys
+        hostPath:
+          path: /sys
+      - name: cadvisor-docker
+        hostPath:
+          path: /var/lib/docker
+      - name: cadvisor-disk
+        hostPath:
+          path: /dev/disk

--- a/system/nodex.yaml
+++ b/system/nodex.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter
+  namespace: micado-worker
+  labels:
+    app.kubernetes.io/name: node-exporter
+    app.kubernetes.io/managed-by: micado
+    app.kubernetes.io/version: v0.18.1
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: node-exporter
+      app.kubernetes.io/managed-by: micado
+      app.kubernetes.io/version: v0.18.1
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: node-exporter
+        app.kubernetes.io/managed-by: micado
+        app.kubernetes.io/version: v0.18.1
+    spec:
+      containers:
+      - name: node-exporter
+        image: prom/node-exporter:v0.18.1
+        ports:
+        - containerPort: 9100
+        resources:
+          requests:
+            cpu: 25m
+        volumeMounts:
+        - name: nodex-proc
+          mountPath: /host/proc
+          readOnly: true
+        - name: nodex-sys
+          mountPath: /host/sys
+          readOnly: true
+        args:
+          - '--path.procfs=/host/proc'
+          - '--path.sysfs=/host/sys'
+      priorityClassName: micado-priority
+      volumes:
+      - name: nodex-proc
+        hostPath:
+          path: /proc
+      - name: nodex-sys
+        hostPath:
+          path: /sys

--- a/tests/templates/tosca_074.yaml
+++ b/tests/templates/tosca_074.yaml
@@ -82,14 +82,17 @@ topology_template:
         image: happy-image
         ports:
         - port: 3000
-      interfaces:
-        Kubernetes:
-          create:
-            inputs:
-              kind: Deployment
-              subdomain: test-podspec
-              metadata:
-                namespace: "custom-ns"
+        - port: 4000
+
+    docker-by-kube-service:
+      type: tosca.nodes.MiCADO.Container.Application.Docker
+      properties:
+        image: happy-image
+        ports:
+        - port: 3000
+        - port: 4000
+          metadata:
+            namespace: service-ns
     
 
     add-container-to-workload:

--- a/tests/test_k8s_translation.py
+++ b/tests/test_k8s_translation.py
@@ -357,23 +357,28 @@ class TestK8sTranslation(unittest.TestCase):
             30009,
         )
 
-    def test_create_service_with_namespace(self):
+    def test_create_service_use_parent_namespace(self):
         cont = self.getContainerbyName("docker-by-kube")
-        spec = utils.get_lifecycle(cont, "Kubernetes")
+        spec = {"create": {"metadata": {"namespace": "custom-ns"}}}
         test = WorkloadManifest("myapp", cont, spec, self.tpl.repositories)
-        self.assertEqual(
-            test.services.get("docker-by-kube")
-            .resource.get("spec")
-            .get("ports")[0]
-            .get("port"),
-            3000,
-        )
         self.assertEqual(test.services.get("docker-by-kube").namespace, "custom-ns")
         self.assertEqual(
             test.services.get("docker-by-kube")
             .resource.get("metadata")
             .get("namespace"),
             "custom-ns",
+        )
+
+    def test_create_service_use_service_namespace(self):
+        cont = self.getContainerbyName("docker-by-kube-service")
+        spec = {"create": {"metadata": {"namespace": "custom-ns"}}}
+        test = WorkloadManifest("myapp", cont, spec, self.tpl.repositories)
+        self.assertEqual(test.services.get("docker-by-kube-service").namespace, "service-ns")
+        self.assertEqual(
+            test.services.get("docker-by-kube-service")
+            .resource.get("metadata")
+            .get("namespace"),
+            "service-ns",
         )
 
     """ Test volumes, requirements, VolumeManifest """


### PR DESCRIPTION
Reads from a _tosca.policies.Monitoring.MiCADO_ policy to enable node exporter / cadvisor for an application
Also adds support for:
* declarative updates through _kubectl apply --prune_
* better handling of custom kubernetes namespaces